### PR TITLE
Remove ops heading and move contents to guides

### DIFF
--- a/source/_pages/guides/installation_guide.md
+++ b/source/_pages/guides/installation_guide.md
@@ -1,7 +1,7 @@
 ---
 title: Installation
 layout: default
-top_nav: ops
+top_nav: guides
 outdated: true
 ---
 # How to Install the Gravity-Platform

--- a/source/_pages/ops.md
+++ b/source/_pages/ops.md
@@ -1,5 +1,0 @@
----
-title: Ops$picto-settings
-layout: default
-top_nav: ops
----


### PR DESCRIPTION
After having cleaned up the front page this removes one mostly unused level of complexity. Next up I'm gonna start adding stuff to `api.md` and `guides.md`. Our docs need more and better onboarding instructions!