### PR TITLE
Rewrite developer guide

### DIFF
--- a/source/_pages/guides/developer_guide.md
+++ b/source/_pages/guides/developer_guide.md
@@ -2,7 +2,6 @@
 title: Developer
 layout: default
 top_nav: guides
-outdated: true
 ---
 # How to Hack the Gravity-Platform
 

--- a/source/_pages/guides/developer_guide.md
+++ b/source/_pages/guides/developer_guide.md
@@ -115,3 +115,8 @@ git clone git@github.com:gravity-platform/vagrant-centos-7-php.git
 cd vagrant-centos-7-php
 vagrant up
 ```
+
+## Further reading
+
+* [API docs](/api/)
+* [JSON definition guide](/guides/json_definition_guide/)

--- a/source/_pages/guides/developer_guide.md
+++ b/source/_pages/guides/developer_guide.md
@@ -8,7 +8,7 @@ top_nav: guides
 Are you new to hacking on graviton and graviton based services? This document aims at
 getting your local development infrastructure up and running.
 
-It assumes that you have a general idea of how modern multitier architecture and tries
+It assumes that you have a general idea of how modern multitier architecture works and tries
 to contain enough information to help getting people from various it backgrounds started.
 
 ## Overview
@@ -21,8 +21,8 @@ into the following tiers.
 - several workers as logic tier
 - various angular2 or mobile native presentation tiers that stay in-house for the most part
 
-Along with several supporting services all these services make out what we consider a kind
-of gravity platform for the sake of this documentation.
+Along with several supporting services all these services make out what we consider a gravity
+platform.
 
 ## Requirements
 
@@ -32,9 +32,9 @@ We recommend copious amounts of RAM as well as a fast SSD for being able to work
 You will probably get away with HDD based systems and 4 GB of RAM but you will certainly incur
 a noticable performance penalty.
 
-Due to the fact that all parts of the stack run on GNU/Linux at runtime, the single most efficient
-way to develop with the platform is on a linux box. Using a virtual box is fine and actually
-encouraged since it leads to a more stable development environment in all cases.
+Due to the fact that all parts of the stack run on [GNU/Linux](https://www.linux.com/) at runtime, 
+the single most efficient way to develop with the platform is on a linux box. Using a virtual box
+is fine and actually encouraged since it leads to a more stable development environment in all cases.
 
 The most used cases used by platform developers at the moment are usually using
 [VirtualBox](https://www.virtualbox.org/) on either [OS X](http://www.apple.com/osx/) or
@@ -60,15 +60,12 @@ Have a look at the organizations the repos are in if you are looking for more bi
 ## The commons
 
 All our repos have some things in common. They all contain a README.md that explains what the
-repository is about. The follow [git-flow](http://nvie.com/posts/a-successful-git-branching-model/)
-conventions and contain the bare code without any build artefacts. We strive at keeping the code
-at a deployable state and the repos usually contain automation to that effect. To aid in proper
-communication about code we follow the [semver](http://semver.org/spec/v2.0.0.html) versioning
-standard.
+repository is about. They follow [git-flow](http://nvie.com/git-model/) conventions and contain 
+the bare code without any build artefacts. We strive to keep the code in a deployable state and 
+the repos usually contain automation to that effect. To aid proper communication about the code 
+we follow the [semver](http://semver.org/spec/v2.0.0.html) versioning standard.
 
 ### git-flow
-
-We use the [``git-flow``](http://nvie.com/git-model/) system for version control wherever possible.
 
 If you want to use the model effectively it is highly recommend that you look into tooling to do so.
 Regular git users may find  the [gitflow tool](https://github.com/nvie/gitflow) handy and there are
@@ -95,7 +92,7 @@ all the merges in ``develop`` or in ``hotfixes``.
 The gravity-platform makes heavy use of multiple package repositories. The repositories being used
 are detailed in this guide.
 
-The PHP package archive [packagist](https://packagist.org/) is used for all open PHP code. Additionally there are some private bundle only available to select partners on our internal satis server.
+The PHP package archive [packagist](https://packagist.org/) is used for all open PHP code. Additionally there are some private bundles only available to select partners on our internal satis server.
 
 Node packaged modules [npm](https://npmjs.org/) are used during the build phase of JavaScript based
 projects.

--- a/source/_pages/guides/developer_guide.md
+++ b/source/_pages/guides/developer_guide.md
@@ -68,120 +68,36 @@ standard.
 
 ### git-flow
 
-The gravity-platform SHALL use [``git-flow``](http://nvie.com/git-model/) for version control.
-We make the OPTIONAL recommendation to use the [gitflow tool](https://github.com/nvie/gitflow).
+We use the [``git-flow``](http://nvie.com/git-model/) system for version control wherever possible.
+
+If you want to use the model effectively it is highly recommend that you look into tooling to do so.
+Regular git users may find  the [gitflow tool](https://github.com/nvie/gitflow) handy and there are
+also implementations for many major platforms.
+
 Further reading on ``git-flow`` may be found on the excellent
 [``git-flow`` cheatsheet](http://danielkummer.github.io/git-flow-cheatsheet/).
 
-You MUST use the ``git-flow`` model on the aforementioned github organisations.
-Is is RECOMMENDED that you also use ``git-flow`` on internal applications based on the gravity-platform.
-You MUST use the default branch prefixes given by ``git-flow`` except for the version tag prefix
-which SHALL be ``v``. As an exception to the stated rule, the gravity-platform/doc git repository
-MUST use the ``gh-pages`` branch as default.
+We usually use the default branch prefixes given by ``git-flow`` except for the version tag prefix
+which is ``v``. If you stray from this well lit path you should add documentation on the effect to
+the repos readme.
 
 ### Semantic Versioning
 
 It is very import for packages to not only be versioned but for these versions to
-convey a clear and semantic meaning. Thus all packages in the aforementioned repositories
-MUST follow the rules given in the [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)
+convey a clear and semantic meaning. This is why we follow the rules given in the [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)
 specification.
 
-Incrementing the version SHOULD be done on a ``release`` branch after carefully considering
-all the merges in ``develop`` or in ``hotfixes``. On the ``develop`` branch the version number
-SHOULD always point to the next MINOR version and be postfixed with ``-dev``.
+Incrementing the version is done on a ``release`` branch after carefully considering
+all the merges in ``develop`` or in ``hotfixes``.
 
 ## Package Repositories
 
 The gravity-platform makes heavy use of multiple package repositories. The repositories being used
-MUST be detailed in this guide.
+are detailed in this guide.
 
-The PHP package archive [packagist](https://packagist.org/) SHALL be used for all PHP code.
+The PHP package archive [packagist](https://packagist.org/) is used for all open PHP code. Additionally there are some private bundle only available to select partners on our internal satis server.
 
-Node packaged modules [npm](https://npmjs.org/) SHOULD only be used during the build phase of JavaScript based
+Node packaged modules [npm](https://npmjs.org/) are used during the build phase of JavaScript based
 projects.
 
-Precompiled JavaScript components MUST be installed with [Bower components](http://sindresorhus.com/bower-components/)
-before they MAY be compiled into a deliverable using tools from npm.
-
-## Components
-
-### Graviton
-
-#### Services
-
-##### Generating a Service
-
-The service generator MAY be called as follows.
-
-````
-php app/console graviton:generate:resource --entity=GravitonFooBundle:Bar --format=xml --fields="name:string" --with-repository --no-interaction
-````
-
-Please refer to ``php app/console generate:doctrine:entities --help`` for further usage information.
-
-After generating a new service you MUST review the code before committing it proper.
-
-##### Service Anatomy
-
-Each graviton service SHALL consist of the following files. The following example was taken from the ``/core/app`` service.
-
-<table>
-  <tr>
-    <th>File/Directory</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle</code></td>
-    <td>bundle directory, contains all the files related to a bundle</td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/Controller/AppController.php</code></td>
-    <td>controller for <code>/core/app</code> service, MUST extend <code>Graviton\RestBundle\Controller\RestController</code></td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/DataFixtures/MongoDB/LoadAppData.php</code></td>
-    <td>fixture loader, loads fixtures on initial install and during testing, MUST implement <code>Doctrine\Common\DataFixtures\FixtureInterface</code></td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/Document/App.php</code></td>
-    <td>service document, access a single instance of an item, SHOULD implement <code>Graviton\I18nBundle\Document\TranslatableDocumentInterface</code></td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/Model/App.php</code></td>
-    <td>service mode, wrapper around document and repository, adds schema information for a service, MUST extend <code>Graviton\RestBundle\Model\DocumentModel</code></td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/Repository/AppRepository.php</code></td>
-    <td>service repository, access collections of documents, MUST extend <code>Doctrine\ODM\MongoDB\DocumentRepository</code></td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/Resources/config/doctrine/App.mongodb.xml</code></td>
-    <td>MongoDB config, defines how data is persisted</td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/Resources/config/schema/App.json</code></td>
-    <td>model config, schema information for the service</td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/Resources/config/serializer/Document.App.xml</code></td>
-    <td>serializer config, defines how data is serialized and deserialized to the client</td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/Resources/config/services.xml</code></td>
-    <td><abbr title="Dependency Injection Container">DIC</abbr> configuration, define services for classes needed by the service</td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/Resources/config/validation.xml</code></td>
-    <td>Validation constraints for service data</td>
-  </tr>
-  <tr>
-    <td><code>src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php</code></td>
-    <td>service tests, e2e tests that make later refactoring possible, MUST extend <code>Graviton\TestBundle\Test\RestTestCase</code></td>
-  </tr>
-</table>
-
-You MAY look at [CoreBundles code](https://github.com/libgraviton/graviton/tree/develop/src/Graviton/CoreBundle) to see  this in action.
-
-If you want to manually create a service you MUST implement all the above elements. It is RECOMMENDED that you use the aformentioned ``graviton:generate:resource`` for all you service creation needs.
-
-### Graviphoton
+Precompiled JavaScript components for the browser can be installed with [Bower components](http://sindresorhus.com/bower-components/) or with npm as required.

--- a/source/_pages/guides/developer_guide.md
+++ b/source/_pages/guides/developer_guide.md
@@ -89,7 +89,7 @@ specification.
 Incrementing the version is done on a ``release`` branch after carefully considering
 all the merges in ``develop`` or in ``hotfixes``.
 
-## Package Repositories
+### Package Repositories
 
 The gravity-platform makes heavy use of multiple package repositories. The repositories being used
 are detailed in this guide.

--- a/source/_pages/guides/developer_guide.md
+++ b/source/_pages/guides/developer_guide.md
@@ -6,24 +6,67 @@ outdated: true
 ---
 # How to Hack the Gravity-Platform
 
-This document show how to hack the gravity-platform in a most effectiv fashion.
+Are you new to hacking on graviton and graviton based services? This document aims at
+getting your local development infrastructure up and running.
 
-> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-> "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in
-> this document are to be interpreted as described in RFC 2119.
+It assumes that you have a general idea of how modern multitier architecture and tries
+to contain enough information to help getting people from various it backgrounds started.
 
-This document has a normative character and all developers MUST follow the
-guidelines given.
+## Overview
 
-## Code Repositories
+Our gravity-platform services are written in a few different languages and are organized
+into the following tiers.
 
-The gravity-platform SHALL be hosted on the following github organisations.
+- mongodb as data tier
+- graviton, a symfony 2 based JSON/REST server generation toolkit as api tier
+- several workers as logic tier
+- various angular2 or mobile native presentation tiers that stay in-house for the most part
 
-- [libgraviton](https://github.com/libgraviton)
-- [graviphoton](https://github.com/graviphoton)
-- [gravity-platform](https://github.com/gravity-platform)
+Along with several supporting services all these services make out what we consider a kind
+of gravity platform for the sake of this documentation.
 
-## ``git-flow``
+## Requirements
+
+For you to start developing on most parts of the platform you will need a suitable workstation.
+
+We recommend copiouos amounts of RAM as well as a fast SSD for being able to work effectivly.
+You will probably get away with HDD based systems and 4 GB of RAM but you will certainly incur
+a noticable performance penalty.
+
+Due to the fact that all parts of the stack run on GNU/Linux at runtime, the single most efficient
+way to develop with the platform is on a linux box. Using a virtual box is fine and actually
+encouraged since it leads to a more stable development environment in all cases.
+
+The most used cases used by platform developers at the moment are usually using
+[VirtualBox](https://www.virtualbox.org/) on either OS X or Windows.
+
+In theory it is also possible to run all the tools native. Using a modern GNU/Linux distribution
+this is easy to set up and do, on OS X it is only for the brave (and maybe slightly mad) and
+on Windows running natively is mostly likely for the insane. We don't remember anyone returning
+from going down the last path.
+
+## Where wild codes are
+
+Large parts of our code are in the open and available through github. The following list points
+out the key repositories and what they contain.
+
+- [graviton rest server generator](https://github.com/libgraviton/graviton)
+- [libs for building angular clients](https://github.com/graviphoton)
+- [work base lib](https://github.com/libgraviton/graviton-worker-base-java)
+- [these docs](https://github.com/gravity-platform/doc)
+
+Have a look at the organizations the repos are in if you are looking for more bits and pieces.
+
+## The commons
+
+All our repos have some things in common. They all contain a README.md that explains what the
+repository is about. The follow [git-flow](http://nvie.com/posts/a-successful-git-branching-model/)
+conventions and contain the bare code without any build artefacts. We strive at keeping the code
+at a deployable state and the repos usually contain automation to that effect. To aid in proper
+communication about code we follow the [semver](http://semver.org/spec/v2.0.0.html) versioning
+standard.
+
+### git-flow
 
 The gravity-platform SHALL use [``git-flow``](http://nvie.com/git-model/) for version control.
 We make the OPTIONAL recommendation to use the [gitflow tool](https://github.com/nvie/gitflow).
@@ -36,7 +79,7 @@ You MUST use the default branch prefixes given by ``git-flow`` except for the ve
 which SHALL be ``v``. As an exception to the stated rule, the gravity-platform/doc git repository
 MUST use the ``gh-pages`` branch as default.
 
-## Semantic Versioning
+### Semantic Versioning
 
 It is very import for packages to not only be versioned but for these versions to
 convey a clear and semantic meaning. Thus all packages in the aforementioned repositories

--- a/source/_pages/guides/developer_guide.md
+++ b/source/_pages/guides/developer_guide.md
@@ -101,3 +101,17 @@ Node packaged modules [npm](https://npmjs.org/) are used during the build phase 
 projects.
 
 Precompiled JavaScript components for the browser can be installed with [Bower components](http://sindresorhus.com/bower-components/) or with npm as required.
+
+## Developer box
+
+You can find tools needed to run graviton on [vagrant](https://www.vagrantup.com/) for dev purposes in our [vagrant-centos-7-php](https://github.com/gravity-platform/vagrant-centos-7-php) repo.
+
+The vagrant setup makes it possible for you to do graviton development on non GNU/Linux
+platform by emulating them on you existing machine. After intalling vagrant you may clone
+the Vagranfile and start the install.
+
+```
+git clone git@github.com:gravity-platform/vagrant-centos-7-php.git
+cd vagrant-centos-7-php
+vagrant up
+```

--- a/source/_pages/guides/developer_guide.md
+++ b/source/_pages/guides/developer_guide.md
@@ -19,7 +19,7 @@ into the following tiers.
 - [mongodb](https://www.mongodb.org/) as data tier
 - graviton, a [symfony](https://symfony.com/) based JSON/REST server generation toolkit as api tier
 - several workers as logic tier
-- various angular2 or mobile native presentation tiers that stay in-house for the most part
+- various presentation tiers that stay in-house for the most part
 
 Along with several supporting services all these services make out what we consider a gravity
 platform.

--- a/source/_pages/guides/developer_guide.md
+++ b/source/_pages/guides/developer_guide.md
@@ -16,8 +16,8 @@ to contain enough information to help getting people from various it backgrounds
 Our gravity-platform services are written in a few different languages and are organized
 into the following tiers.
 
-- mongodb as data tier
-- graviton, a symfony 2 based JSON/REST server generation toolkit as api tier
+- [mongodb](https://www.mongodb.org/) as data tier
+- graviton, a [symfony](https://symfony.com/) based JSON/REST server generation toolkit as api tier
 - several workers as logic tier
 - various angular2 or mobile native presentation tiers that stay in-house for the most part
 
@@ -28,7 +28,7 @@ of gravity platform for the sake of this documentation.
 
 For you to start developing on most parts of the platform you will need a suitable workstation.
 
-We recommend copiouos amounts of RAM as well as a fast SSD for being able to work effectivly.
+We recommend copious amounts of RAM as well as a fast SSD for being able to work effectivly.
 You will probably get away with HDD based systems and 4 GB of RAM but you will certainly incur
 a noticable performance penalty.
 
@@ -37,7 +37,8 @@ way to develop with the platform is on a linux box. Using a virtual box is fine 
 encouraged since it leads to a more stable development environment in all cases.
 
 The most used cases used by platform developers at the moment are usually using
-[VirtualBox](https://www.virtualbox.org/) on either OS X or Windows.
+[VirtualBox](https://www.virtualbox.org/) on either [OS X](http://www.apple.com/osx/) or
+[Windows](https://www.microsoft.com/windows).
 
 In theory it is also possible to run all the tools native. Using a modern GNU/Linux distribution
 this is easy to set up and do, on OS X it is only for the brave (and maybe slightly mad) and

--- a/source/_pages/guides/service_generator_guide.md
+++ b/source/_pages/guides/service_generator_guide.md
@@ -1,0 +1,86 @@
+---
+title: Services
+layout: default
+top_nav: guides
+outdated: true
+---
+# Creating Graviton Services
+
+#### Services
+
+##### Generating a Service
+
+The service generator MAY be called as follows.
+
+````
+php app/console graviton:generate:resource --entity=GravitonFooBundle:Bar --format=xml --fields="name:string" --with-repository --no-interaction
+````
+
+Please refer to ``php app/console generate:doctrine:entities --help`` for further usage information.
+
+After generating a new service you MUST review the code before committing it proper.
+
+##### Service Anatomy
+
+Each graviton service SHALL consist of the following files. The following example was taken from the ``/core/app`` service.
+
+<table>
+  <tr>
+    <th>File/Directory</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle</code></td>
+    <td>bundle directory, contains all the files related to a bundle</td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/Controller/AppController.php</code></td>
+    <td>controller for <code>/core/app</code> service, MUST extend <code>Graviton\RestBundle\Controller\RestController</code></td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/DataFixtures/MongoDB/LoadAppData.php</code></td>
+    <td>fixture loader, loads fixtures on initial install and during testing, MUST implement <code>Doctrine\Common\DataFixtures\FixtureInterface</code></td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/Document/App.php</code></td>
+    <td>service document, access a single instance of an item, SHOULD implement <code>Graviton\I18nBundle\Document\TranslatableDocumentInterface</code></td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/Model/App.php</code></td>
+    <td>service mode, wrapper around document and repository, adds schema information for a service, MUST extend <code>Graviton\RestBundle\Model\DocumentModel</code></td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/Repository/AppRepository.php</code></td>
+    <td>service repository, access collections of documents, MUST extend <code>Doctrine\ODM\MongoDB\DocumentRepository</code></td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/Resources/config/doctrine/App.mongodb.xml</code></td>
+    <td>MongoDB config, defines how data is persisted</td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/Resources/config/schema/App.json</code></td>
+    <td>model config, schema information for the service</td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/Resources/config/serializer/Document.App.xml</code></td>
+    <td>serializer config, defines how data is serialized and deserialized to the client</td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/Resources/config/services.xml</code></td>
+    <td><abbr title="Dependency Injection Container">DIC</abbr> configuration, define services for classes needed by the service</td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/Resources/config/validation.xml</code></td>
+    <td>Validation constraints for service data</td>
+  </tr>
+  <tr>
+    <td><code>src/Graviton/CoreBundle/Tests/Controller/AppControllerTest.php</code></td>
+    <td>service tests, e2e tests that make later refactoring possible, MUST extend <code>Graviton\TestBundle\Test\RestTestCase</code></td>
+  </tr>
+</table>
+
+You MAY look at [CoreBundles code](https://github.com/libgraviton/graviton/tree/develop/src/Graviton/CoreBundle) to see  this in action.
+
+If you want to manually create a service you MUST implement all the above elements. It is RECOMMENDED that you use the aformentioned ``graviton:generate:resource`` for all you service creation needs.
+
+### Graviphoton


### PR DESCRIPTION
It's now more of an introduction to our development infra rather than a disfunctional normativy non-normative text.

The latter parts that are still written in RFC 2119 style still need refactoring and I'm thinking about
adding more docs on the vagrant setup.

I might also start writing up my new docker setup that almost makes sense locally. It's rather close to how we deploy but still needs some finishing touches and tests.

I'm opening this as a PR now since I'd like to gauge some interest. What would be more appealing to folks? More on the (might i add badly-maintained) [vagrant setup](https://github.com/gravity-platform/vagrant-centos-7-php) or more on a new docker based approach that has been ripening on my SSDs for sometime now.

If the latter has any demand I might as well start consolidating my >9000 repos on that and finish it before doing/redoing that part of this doc.

I've WIPed this PR for now, feel free to push into it as will as long as you stay on topic with the general spirit of the file. Maybe the following tasks inspire someone to put some time into this.

* [x] rewrite remaining RFC 2119 sections
* [x] add heaps more links to ALL THE THINGS
* [X] ~~add~~ remove graviton stuff
* [x] ~~add frontend & worker stuff~~
* [x] add vagrant box setup instructions
* [x] proofread